### PR TITLE
fix(common): upgrade react-redux with createSelectorHook

### DIFF
--- a/packages/child-app/src/views/SignatureConfirm.tsx
+++ b/packages/child-app/src/views/SignatureConfirm.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
-import { CoreContext } from "@kirby-web3/child-react";
-import { useSelector } from "react-redux";
+import { CoreContext, useSelector } from "@kirby-web3/child-react";
 import { SignatureInterceptorPlugin } from "@kirby-web3/plugin-ethereum";
 import { RouteComponentProps } from "@reach/router";
 
 export const SignatureConfirm: React.FunctionComponent<RouteComponentProps> = () => {
-  const maybeCore = React.useContext(CoreContext);
-  const sig = maybeCore!.plugins.signatureInterceptor as SignatureInterceptorPlugin;
+  const ctx = React.useContext(CoreContext);
+  const sig = ctx.core.plugins.signatureInterceptor as SignatureInterceptorPlugin;
 
   const kirbyData = useSelector((state: any) => {
     return sig.getSignatureRequest();

--- a/packages/child-app/src/views/Web3Enable.tsx
+++ b/packages/child-app/src/views/Web3Enable.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
-import { LogInWithMetaMask, LogInWithPortis, LogInWithBurner, CoreContext } from "@kirby-web3/child-react";
+import { LogInWithMetaMask, LogInWithPortis, LogInWithBurner, CoreContext, useSelector } from "@kirby-web3/child-react";
 import { EthereumChildPlugin } from "@kirby-web3/plugin-ethereum";
 import { RouteComponentProps } from "@reach/router";
-import { useSelector } from "react-redux";
 import { ViewPlugin } from "@kirby-web3/child-core/build/ViewPlugin";
 
 export const Web3Enable: React.FC<RouteComponentProps> = () => {
-  const maybeCore = React.useContext(CoreContext);
+  const ctx = React.useContext(CoreContext);
   const requestID = useSelector((state: any) => {
     if (state.view && state.view.queue && state.view.queue[0]) {
       return state.view.queue[0].requestID;
@@ -14,10 +13,10 @@ export const Web3Enable: React.FC<RouteComponentProps> = () => {
   });
   function selection(provider: string): void {
     console.log("selected:", provider);
-    (maybeCore!.plugins.ethereum as EthereumChildPlugin).enableWeb3(provider, requestID).catch(err => {
+    (ctx.core.plugins.ethereum as EthereumChildPlugin).enableWeb3(provider, requestID).catch(err => {
       console.log("error with enableWeb3: ", err);
     });
-    (maybeCore!.plugins.view as ViewPlugin).completeView();
+    (ctx.core.plugins.view as ViewPlugin).completeView();
   }
   return (
     <div>

--- a/packages/child-react/package.json
+++ b/packages/child-react/package.json
@@ -12,11 +12,11 @@
     "dependencies": {
         "@kirby-web3/child-core": "1.0.0",
         "@types/react": "^16.8.23",
-        "@types/react-redux": "^7.1.1",
+        "@types/react-redux": "^7.1.2",
         "@types/styled-components": "^4.1.18",
         "react": "^16.8.6",
         "react-dom": "^16.8.6",
-        "react-redux": "^7.1.0",
+        "react-redux": "^7.1.1",
         "react-svg": "^10.0.17",
         "styled-components": "^4.3.2"
     },

--- a/packages/parent-react/package.json
+++ b/packages/parent-react/package.json
@@ -13,9 +13,9 @@
         "@kirby-web3/parent-core": "1.0.0",
         "@kirby-web3/plugin-ethereum": "1.0.0",
         "@types/react": "^16.8.23",
-        "@types/react-redux": "^7.1.1",
+        "@types/react-redux": "^7.1.2",
         "react": "^16.8.6",
-        "react-redux": "^7.1.0",
+        "react-redux": "^7.1.1",
         "redux": "^4.0.4"
     },
     "devDependencies": {

--- a/packages/parent-react/src/Web3FrameProvider.tsx
+++ b/packages/parent-react/src/Web3FrameProvider.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Kirby, ParentPlugin } from "@kirby-web3/parent-core";
-import { Provider, ReactReduxContextValue, useStore, useDispatch, useSelector } from "react-redux";
+// @ts-ignore: @types/react-redux doesn't have create*Hook yet
+import { Provider, ReactReduxContextValue, createStoreHook, createDispatchHook, createSelectorHook } from "react-redux";
 
 export interface IKirbyContext extends ReactReduxContextValue {
   kirby: Kirby;
@@ -10,18 +11,9 @@ const kirby = new Kirby();
 const startingContext: IKirbyContext = { kirby, store: kirby.redux, storeState: {} };
 export const KirbyContext = React.createContext(startingContext);
 
-// @ts-ignore
-export const KirbyReduxContext = React.createContext<ReactReduxContextValue>(null);
-
-// TODO(dankins): if people are using redux this is going to conflict
-// https://react-redux.js.org/next/api/hooks#custom-context
-// redux#next has the hooks to create a context-aware store, but is not released yet
-
-// export const useStore = createStoreHook(KirbyReduxContext);
-// export const useDispatch = createDispatchHook(KirbyReduxContext);
-// export const useSelector = createSelectorHook(KirbyReduxContext);
-// TOOD(dankins): reexporting these for now, but this is bad
-export { useSelector, useStore, useDispatch };
+export const useStore = createStoreHook(KirbyContext);
+export const useDispatch = createDispatchHook(KirbyContext);
+export const useSelector = createSelectorHook(KirbyContext);
 
 export interface KirbyProviderProps {
   config: any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2456,10 +2456,10 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react-redux@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.1.tgz#eb01e89cf71cad77df9f442b819d5db692b997cb"
-  integrity sha512-owqNahzE8en/jR4NtrUJDJya3tKru7CIEGSRL/pVS84LtSCdSoT7qZTkrbBd3S4Lp11sAp+7LsvxIeONJVKMnw==
+"@types/react-redux@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.2.tgz#02303b77d87e54f327c09507cf80ee3ca3063898"
+  integrity sha512-Iim6UCtD0mZX9U3jBuT6ZObBZ8UlakoOgefiRgi5wakfbNnXd3TUwwUMgi3Ijc0fxsPLZ5ULoz0oDy15YIaLmQ==
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"
@@ -13597,7 +13597,7 @@ react-error-overlay@^6.0.1:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.1.tgz#b8d3cf9bb991c02883225c48044cb3ee20413e0f"
   integrity sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw==
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.6:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.6, react-is@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
@@ -13622,6 +13622,18 @@ react-redux@^7.1.0:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.8.6"
+
+react-redux@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.1.tgz#ce6eee1b734a7a76e0788b3309bf78ff6b34fa0a"
+  integrity sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-scripts@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
fixes this todo:
// TODO(dankins): if people are using redux this is going to conflict	
// https://react-redux.js.org/next/api/hooks#custom-context	
// redux#next has the hooks to create a context-aware store, but is not released yet