### PR TITLE
fix(common): use context on redux Provider

### DIFF
--- a/packages/child-react/src/KirbyChildProvider.tsx
+++ b/packages/child-react/src/KirbyChildProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 // @ts-ignore: @types/react-redux doesn't have create*Hook yet
-import { Provider, createStoreHook, createDispatchHook, createSelectorHook } from "react-redux";
+import { Provider, createStoreHook, createDispatchHook, createSelectorHook, ReactReduxContextValue } from "react-redux";
 import { ThemeProvider } from "styled-components";
 import { ChildCore, ChildPlugin } from "@kirby-web3/child-core";
 import { Theme, DefaultTheme } from "./Theme";
@@ -11,12 +11,12 @@ export interface KirbyChildProviderProps {
   config?: any;
 }
 
-export interface ICoreContext {
+export interface ICoreContext extends ReactReduxContextValue {
   core: ChildCore;
-  store: any;
 }
 const core = new ChildCore();
 const startingContext = { core, store: core.redux, storeState: {} };
+export const ReduxContext = React.createContext<ReactReduxContextValue>(startingContext);
 export const CoreContext = React.createContext<ICoreContext>(startingContext);
 
 export const useStore = createStoreHook(CoreContext);
@@ -35,7 +35,7 @@ export const KirbyChildProvider: React.FC<KirbyChildProviderProps> = ({ plugins,
   return (
     <ThemeProvider theme={theme || DefaultTheme}>
       <CoreContext.Provider value={context}>
-        <Provider store={core.redux}>
+        <Provider context={ReduxContext} store={core.redux}>
           <div>{children}</div>
         </Provider>
       </CoreContext.Provider>

--- a/packages/parent-react/src/Web3FrameProvider.tsx
+++ b/packages/parent-react/src/Web3FrameProvider.tsx
@@ -9,6 +9,7 @@ export interface IKirbyContext extends ReactReduxContextValue {
 
 const kirby = new Kirby();
 const startingContext: IKirbyContext = { kirby, store: kirby.redux, storeState: {} };
+export const ReduxContext = React.createContext<ReactReduxContextValue>(startingContext);
 export const KirbyContext = React.createContext(startingContext);
 
 export const useStore = createStoreHook(KirbyContext);
@@ -31,7 +32,9 @@ export const KirbyProvider: React.FunctionComponent<KirbyProviderProps> = ({ plu
   return (
     <>
       <KirbyContext.Provider value={context}>
-        <Provider store={kirby.redux}>{children}</Provider>
+        <Provider context={ReduxContext} store={kirby.redux}>
+          {children}
+        </Provider>
       </KirbyContext.Provider>
     </>
   );


### PR DESCRIPTION
if the implementing application uses Redux previously this would overwrite the store, so we should be setting the cotnext in the provider