### PR TITLE
feat(child-core): site preferences

### DIFF
--- a/packages/child-core/package.json
+++ b/packages/child-core/package.json
@@ -13,9 +13,11 @@
     "@kirby-web3/common": "^1.0.0",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",
+    "js-cookie": "^2.2.1",
     "redux": "^4.0.4"
   },
   "devDependencies": {
+    "@types/js-cookie": "^2.2.2",
     "typescript": "^3.5.3"
   },
   "publishConfig": {

--- a/packages/plugin-connext/package.json
+++ b/packages/plugin-connext/package.json
@@ -13,7 +13,7 @@
     "@kirby-web3/child-core": "^1.0.0",
     "@kirby-web3/common": "^1.0.0",
     "@kirby-web3/parent-core": "^1.0.0",
-    "@kirby-web3/plugin-ethereum": "^1.3.0",
+    "@kirby-web3/plugin-ethereum": "^1.0.0",
     "@portis/web3": "^2.0.0-beta.36",
     "burner-provider": "^1.0.5",
     "debug": "^4.1.1",

--- a/packages/plugin-connext/src/ConnextChildPlugin.ts
+++ b/packages/plugin-connext/src/ConnextChildPlugin.ts
@@ -2,7 +2,7 @@ import { Action, MiddlewareAPI, Dispatch } from "redux";
 import { ChildPlugin, ParentHandlerActions, PARENT_REQUEST, ParentHandler } from "@kirby-web3/child-core";
 import { EthereumChildPlugin } from "@kirby-web3/plugin-ethereum";
 // import * as connext from "@connext/client";
-import { Wallet, ethers } from "ethers";
+import { ethers } from "ethers";
 
 import { store } from "./store";
 import {
@@ -114,16 +114,12 @@ export class ConnextChildPlugin extends ChildPlugin<ChildConfig, ChildDependenci
   }
 
   public getMnemonic(): string {
-    const CONNEXT_MNEMONIC = "CONNEXT_MNEMONIC";
-    let mnemonic = localStorage.getItem(CONNEXT_MNEMONIC);
+    const ethereumPlugin = this.dependencies.ethereum as EthereumChildPlugin;
+    const parentHandlerPlugin = this.dependencies.ethereum as ParentHandler;
+    // use this just for the side effect of setting the cookie preference
+    ethereumPlugin.getBurnerProvider("rinkeby");
 
-    if (!mnemonic) {
-      const wallet = Wallet.createRandom();
-      mnemonic = wallet.mnemonic;
-      localStorage.setItem(CONNEXT_MNEMONIC, mnemonic);
-    }
-
-    return mnemonic;
+    return parentHandlerPlugin.getSitePreference("burner_mnemonic");
   }
 
   public async openChannel(): Promise<NodeChannel> {

--- a/packages/plugin-ethereum/package.json
+++ b/packages/plugin-ethereum/package.json
@@ -16,6 +16,7 @@
     "@portis/web3": "^2.0.0-beta.36",
     "burner-provider": "^1.0.5",
     "debug": "^4.1.1",
+    "ethers": "^4.0.37",
     "redux": "^4.0.4",
     "web3": "^1.2.1",
     "web3-providers-http": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,56 +1355,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@kirby-web3/child-core@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@kirby-web3/child-core/-/child-core-1.2.0.tgz#2b0297bcfbee6bd9085d61d440db47d9d887481d"
-  integrity sha512-m5AwZJ8kpZmVcipDGrghfB+Rcz5bQZSQJMzT6kIIQ9sjf/sIW8PmTq5jgilwsFBBF+DiRTYePF6RrrJO1J+eeQ==
-  dependencies:
-    "@kirby-web3/common" "1.1.0"
-    "@types/debug" "^4.1.5"
-    debug "^4.1.1"
-    redux "^4.0.4"
-
-"@kirby-web3/common@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@kirby-web3/common/-/common-1.1.0.tgz#e499a370814e3260e99951b67e6e1994e4e22457"
-  integrity sha512-p/TDLJU+AY5XGo8mt3v+Vi40nfzg7lu3CH5x/G5Bc6jaZwfnUHO28CitNzpqY51LmFb2oR7YPVuvhZmXyO/3+g==
-  dependencies:
-    "@types/debug" "^4.1.5"
-    debug "^4.1.1"
-    redux "^4.0.4"
-    redux-dynamic-middlewares "^1.0.0"
-
-"@kirby-web3/parent-core@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@kirby-web3/parent-core/-/parent-core-1.1.0.tgz#e8affdd4c47da94bc006baac9c7ba60482e51c95"
-  integrity sha512-XViFmDkir1dQyjsrEzJqJ4AEV71GrZhQk/WSa3274gF/XrA4vfZ92gvhJdFbY12rqBaJwZMST2Miz59fa306rQ==
-  dependencies:
-    "@kirby-web3/common" "1.1.0"
-    debug "^4.1.1"
-    events "^3.0.0"
-    redux "^4.0.4"
-    web3 "^1.2.0"
-    web3-providers-http "^1.2.0"
-    web3-providers-ws "^1.2.0"
-
-"@kirby-web3/plugin-ethereum@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@kirby-web3/plugin-ethereum/-/plugin-ethereum-1.3.0.tgz#075e3fe7f56f8d7a054046600a6287b93d6d8d7a"
-  integrity sha512-5OgK7/n6jIPdvPJplZ4jyQ4jPp0kHo2Br9lZgbcDvOEIWwoUHGr07l+VkUG0Qi627Yw/KOIGT6vhbWZUCYvpFA==
-  dependencies:
-    "@kirby-web3/child-core" "1.2.0"
-    "@kirby-web3/common" "1.1.0"
-    "@kirby-web3/parent-core" "1.1.0"
-    "@portis/web3" "^2.0.0-beta.36"
-    burner-provider "^1.0.5"
-    debug "^4.1.1"
-    redux "^4.0.4"
-    web3 "^1.2.1"
-    web3-providers-http "^1.2.0"
-    web3-providers-ws "^1.2.0"
-    web3-utils "^1.2.1"
-
 "@lerna/add@3.16.2":
   version "3.16.2"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.16.2.tgz#90ecc1be7051cfcec75496ce122f656295bd6e94"
@@ -2735,6 +2685,11 @@
   integrity sha512-MU1HIvWUme74stAoc3mgAi+aMlgKOudgEvQDIm1v4RkrDudBh1T+NFp5sftpBAdXdx1J0PbdpJ+M2EsSOi1djA==
   dependencies:
     "@types/jest-diff" "*"
+
+"@types/js-cookie@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.2.tgz#84e8848e14d44418726ceb52dd887c7bfe45d678"
+  integrity sha512-vkuGzldF9mNsWS9cmmMFfW1rufa7IdPUorS150gKoU/2fzLJ/0LXiMMtRqIBWz0sZ/VF2VxwB25WXEOo6akU6w==
 
 "@types/json-schema@^7.0.3":
   version "7.0.3"
@@ -11457,6 +11412,11 @@ jest@^24.9.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
+
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
starts to address issues with Brave (https://github.com/joincivil/kirby-web3/issues/29)

This introduces "site preferences" that are stored in a cookie under the domain of the child app. Since this is a first-party cookie, Brave shouldn't complain about it. 

This allows us to have features like remembering wallet choice so that provider.enable() doesn't need to pop to the user. "trust this app" a la portis so we don't need to display the signature view, etc etc

In this first pass I am storing the mnemonic per parent domain. I imagine eventually we'll want to have global preferences, but this should do for now. 

Once we have persistence for Verified Claims we could store encrypted preferences somewhere (burner keys, etc) instead of cookies