### PR TITLE
feat(child-core): add `data` to view plugin

### DIFF
--- a/packages/child-app/src/ReachRouterPlugin.tsx
+++ b/packages/child-app/src/ReachRouterPlugin.tsx
@@ -2,13 +2,15 @@ import { MiddlewareAPI, Action } from "redux";
 import { Dispatch } from "react";
 import { ChildPlugin, REQUEST_VIEW_ACTION, COMPLETE_VIEW_ACTION } from "@kirby-web3/child-core";
 import { navigate } from "@reach/router";
+import queryString from "querystring";
 
 export class ReachRouterPlugin extends ChildPlugin {
   public name = "reachRouter";
 
   public middleware = (api: MiddlewareAPI<any>) => (next: Dispatch<any>) => <A extends Action>(action: any): void => {
     if (action.type === REQUEST_VIEW_ACTION) {
-      navigate(action.payload.route);
+      const qs = action.payload.data ? "?" + queryString.encode(action.payload.data) : "";
+      navigate(action.payload.route + qs);
     }
     if (action.type === COMPLETE_VIEW_ACTION) {
       navigate("/");

--- a/packages/child-app/src/viewport/Viewport.tsx
+++ b/packages/child-app/src/viewport/Viewport.tsx
@@ -7,7 +7,7 @@ import { SignatureConfirm } from "../views/SignatureConfirm";
 export const Viewport: React.FC = ({ children }) => {
   return (
     <Router>
-      <Web3Enable path="/ethereum/web3enable/:network" />
+      <Web3Enable path="/ethereum/web3enable" />
       <SignatureConfirm path="/ethereum/confirm-signature" />
     </Router>
   );

--- a/packages/child-core/src/ViewPlugin.ts
+++ b/packages/child-core/src/ViewPlugin.ts
@@ -10,21 +10,15 @@ export interface RequestViewAction {
   type: typeof REQUEST_VIEW_ACTION;
   payload: {
     route: string;
-    requestID: string;
-    dispatchOnComplete?: any;
+    data?: any;
   };
 }
 
 export interface CompleteViewAction {
   type: typeof COMPLETE_VIEW_ACTION;
-  payload: {
-    route: string;
-    requestID: string;
-    dispatchOnComplete?: any;
-  };
 }
 
-export type ViewPluginActions = RequestViewAction;
+export type ViewPluginActions = RequestViewAction | CompleteViewAction;
 
 export interface ViewState {
   queue: any[];
@@ -41,7 +35,7 @@ export class ViewPlugin extends ChildPlugin<any, ViewPluginActions> {
     next(action);
   };
 
-  public reducer(state: any = { queue: [] }, action: any): ViewState {
+  public reducer(state: any = { queue: [] }, action: ViewPluginActions): ViewState {
     switch (action.type) {
       case REQUEST_VIEW_ACTION:
         return { ...state, queue: state.queue.concat(action.payload) };
@@ -53,8 +47,8 @@ export class ViewPlugin extends ChildPlugin<any, ViewPluginActions> {
     return state;
   }
 
-  public requestView(route: string, requestID?: string, dispatchOnComplete?: any): void {
-    this.dispatch({ type: REQUEST_VIEW_ACTION, payload: { route, requestID, dispatchOnComplete } });
+  public requestView(route: string, data?: any): void {
+    this.dispatch({ type: REQUEST_VIEW_ACTION, payload: { route, data } });
   }
 
   public completeView(): void {

--- a/packages/demo/src/home/ReadOnlyMode.tsx
+++ b/packages/demo/src/home/ReadOnlyMode.tsx
@@ -1,20 +1,27 @@
 import * as React from "react";
 import { CenteredTextBlock, FocusWord } from "../components/text";
 import { colors } from "../components/colors";
+import { Button } from "react-bootstrap";
+import { useKirbySelector, KirbyEthereum, KirbyEthereumContext } from "@kirby-web3/ethereum-react";
 
 export const ReadOnlyMode = () => {
+  // state
+  const [loading, setLoading] = React.useState(false);
+  // context
+  const kirby = React.useContext<KirbyEthereum>(KirbyEthereumContext);
+  // kirby
+  const network = useKirbySelector((state: any) => state.ethereum.network);
+
+  async function changeAccount(): Promise<void> {
+    try {
+      await kirby.ethereum.changeAccount();
+    } catch (err) {
+      console.log("error changing account", err);
+    }
+  }
   return (
     <>
-      <CenteredTextBlock>
-        You are in
-        <FocusWord color={colors.red}>read-only</FocusWord>
-        mode
-      </CenteredTextBlock>
-      <CenteredTextBlock>
-        Click
-        <FocusWord color={colors.lightBlue}>Connect</FocusWord>
-        to select a web3 provider
-      </CenteredTextBlock>
+      <Button onClick={changeAccount}>Connect to Ethereum</Button>
     </>
   );
 };

--- a/packages/plugin-ethereum/src/parent/ParentIFrameProvider.ts
+++ b/packages/plugin-ethereum/src/parent/ParentIFrameProvider.ts
@@ -5,7 +5,7 @@ import Web3HttpProvider = require("web3-providers-http");
 
 export class ParentIFrameProvider {
   private dmz: DMZ;
-  private logger = debug("kirby:parent:ParentIFrameProvider");
+  private logger = debug("kirby:parent:ethereum:ParentIFrameProvider");
   private readOnlyProvider: any;
   constructor(dmz: DMZ, readOnlyRPCUrl: string) {
     this.dmz = dmz;


### PR DESCRIPTION
small refactor of the view plugin makes it less reliant on a "route" (with parameters and query string) and just a view name and data you can pass through. This will allow you to build a child app without a routing plugin (ReachRouterPlugin) and thus fix the metamask mobile issue we are seeing